### PR TITLE
Add NODE_OPTIONS to deploy and serve scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "start": "NODE_OPTIONS=--openssl-legacy-provider docusaurus start",
     "build": "NODE_OPTIONS=--openssl-legacy-provider docusaurus build",
     "swizzle": "docusaurus swizzle",
-    "deploy": "docusaurus deploy",
+    "deploy": "NODE_OPTIONS=--openssl-legacy-provider docusaurus deploy",
     "clear": "docusaurus clear",
-    "serve": "docusaurus serve",
+    "serve": "NODE_OPTIONS=--openssl-legacy-provider docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids"
   },


### PR DESCRIPTION
Build/start scripts already had --openssl-legacy-provider for Node 17+ url-loader hash compatibility; add the same prefix to deploy and serve so deploys (and post-build serve) don't crash on the same OpenSSL error.