### PR TITLE
Add Google Analytics (GA4) via gtag preset config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -164,6 +164,10 @@ module.exports = {
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
+        gtag: {
+          trackingID: 'G-F5WBC6JPB3',
+          anonymizeIP: true,
+        },
       },
     ],
   ],


### PR DESCRIPTION
Tracking ID G-F5WBC6JPB3, with anonymizeIP enabled. The gtag plugin ships with @docusaurus/preset-classic, so no new dependency required. Only loads in production builds, not yarn start.